### PR TITLE
Added support for string inequalities

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -318,7 +318,22 @@ function evaluateBinaryExpression(
   if (expression.operator === '==' || expression.operator === '===' || expression.operator === '!=' || expression.operator === '!==') {
     return expression.operator === '==' || expression.operator === '===' ? left === right : left !== right
   }
-
+  
+  if (typeof left === 'string' && typeof right === 'string') {
+    if (expression.operator === '>') {
+      return left > right;
+    }
+    if (expression.operator === '>=') {
+      return left >= right
+    }
+    if (expression.operator === '<') {
+      return left < right
+    }
+    if (expression.operator === '<=') {
+      return left <= right
+    }
+  }
+  
   if (expression.operator === '|>') {
     return (right as (arg: unknown) => unknown)(left)
   }


### PR DESCRIPTION
In our usage of this library, we came across a strange issue where string comparisons were failing.

Previously if your expression contained two strings and you attempted any of the inequality operators, you'd get an error stating that it wasn't a number.

This patch fixes this and works for us.

#### Checks

+ [X] Contains Only One Commit(`git reset` then `git commit`)
+ [X] Build Success(`npm run build`)
+ [X] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
